### PR TITLE
Tentative fix to prevent kicking of user before sending a warning

### DIFF
--- a/TheCrewCommunity/Services/ModeratorWarningService.cs
+++ b/TheCrewCommunity/Services/ModeratorWarningService.cs
@@ -112,16 +112,14 @@ public class ModeratorWarningService(
         if (member is not null)
         {
             await TrySendInfractionMessage(member, embedToUser.Build());
-        }
-        
-        if (kick && member is not null)
-        {
-            await member.RemoveAsync("Exceeded warning limit!");
-        }
-
-        if (ban)
-        {
-            await item.Guild.BanMemberAsync(item.User.Id, 0, "Exceeded warning limit!");
+            if (kick)
+            {
+                await member.RemoveAsync("Exceeded warning limit!");
+            }
+            if (ban)
+            {
+                await item.Guild.BanMemberAsync(item.User.Id, 0, "Exceeded warning limit!");
+            }
         }
 
         moderatorLoggingService.AddToQueue(new ModLogItem(modLog, item.User, warningDescription, ModLogType.Warning, "",item.Attachment));


### PR DESCRIPTION
tentative fix for when a user exceeded infraction levels they were first kicked and only after warned. Adjusted the flow of code to not allow this to occur. Needs testing