### PR TITLE
Update leaderboard page calculation

### DIFF
--- a/TheCrewCommunity/LiveBot/Commands/General/LeaderboardCommand.cs
+++ b/TheCrewCommunity/LiveBot/Commands/General/LeaderboardCommand.cs
@@ -93,7 +93,7 @@ public class LeaderboardCommand(IDbContextFactory<LiveBotDbContext> dbContextFac
         {
             DiscordUser user = await ctx.Client.GetUserAsync(activityList[i].UserID) ?? throw new Exception($"User with ID {activityList[i].UserID} not found");
             User? userInfo = await dbContext.Users.FindAsync(user.Id);
-            stringBuilder.Append(BuildLeaderboardString(i,user,userInfo,activityList[i].Points));
+            stringBuilder.Append(BuildLeaderboardString((page - 1 * 10)+ i,user,userInfo,activityList[i].Points));
         }
 
         var rank = 0;


### PR DESCRIPTION
Fixed the issue with leaderboard page calculation in the LeaderboardCommand module. Now the correct leaderboard page gets displayed by appropriately calculating the index based on the current page number.