### PR TITLE
Upgrade DSharpPlus and replace obsolete method

### DIFF
--- a/TheCrewCommunity/LiveBot/LiveBotService.cs
+++ b/TheCrewCommunity/LiveBot/LiveBotService.cs
@@ -43,7 +43,7 @@ public class LiveBotService(
         commandsExtension.CommandExecuted += SystemEvents.CommandExecuted;
         commandsExtension.CommandErrored += SystemEvents.CommandErrored;
         
-        await commandsExtension.AddProcessorsAsync(
+        commandsExtension.AddProcessors(
             new SlashCommandProcessor(),
             new UserCommandProcessor(),
             new MessageCommandProcessor()

--- a/TheCrewCommunity/TheCrewCommunity.csproj
+++ b/TheCrewCommunity/TheCrewCommunity.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
       <PackageReference Include="AspNet.Security.OAuth.Discord" Version="8.1.0" />
-      <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02313" />
-      <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02313" />
-      <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02313" />
+      <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02345" />
+      <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02345" />
+      <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02345" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">


### PR DESCRIPTION
Upgraded DSharpPlus packages to version 5.0.0-nightly-02345. Replaced the obsolete `AddProcessorsAsync` method with the synchronous `AddProcessors` method in `LiveBotService`.