### PR TITLE
Update vertical image handling in Browse component

### DIFF
--- a/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor
+++ b/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor
@@ -119,14 +119,13 @@
         }, options);
         observer.observe(loadMoreButton);
     }
-    
     function applyOnLoadToImages() {
         let images = document.querySelectorAll('.image-grid img:not(.processed-image):not(.game-logo)');
         console.log('Iterating on all images');
         images.forEach(function(img) {
             img.onload = function() {
                 if (img.naturalHeight > img.naturalWidth) {
-                    img.classList.add('vertical-image');
+                    img.parentNode.classList.add('vertical-image');
                     console.log('Added vertical image class to image');
                 }
                 img.classList.add('processed-image');

--- a/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor.css
+++ b/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor.css
@@ -33,7 +33,11 @@
 }
 .vertical-image{
     grid-row: span 2;
-    max-width: 70% !important;
+    max-width: 90% !important;
+    min-height: 100%;
+}
+.processed-image{
+    min-height: 100%;
 }
 .load-more{
     display: flex;
@@ -55,7 +59,8 @@
 }
 
 @media only screen and (max-width: 400px) {
-    .vertical-image{
+    .vertical-image,
+    .processed-image{
         min-width: 100% !important;
     }
 }


### PR DESCRIPTION
Adjusted the logic to add the 'vertical-image' class to the image's parent container and modified CSS for better vertical image sizing. Ensured consistent styling by defining min-height for the 'processed-image' class.
Fixes https://github.com/BlackLotusLV/TheCrewCommunity/issues/27