### PR TITLE
Remove unused Newtonsoft.Json package reference

### DIFF
--- a/TheCrewCommunity/TheCrewCommunity.csproj
+++ b/TheCrewCommunity/TheCrewCommunity.csproj
@@ -18,7 +18,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
       <PackageReference Include="Serilog" Version="4.0.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />


### PR DESCRIPTION
Eliminated the Newtonsoft.Json package reference from the project file as it was no longer required. This helps reduce potential security vulnerabilities and keeps the project dependencies lean.
closes https://github.com/BlackLotusLV/TheCrewCommunity/issues/18