### PR TITLE
Add Date property to ImageLike

### DIFF
--- a/TheCrewCommunity/Data/WebData/ImageLike.cs
+++ b/TheCrewCommunity/Data/WebData/ImageLike.cs
@@ -9,7 +9,8 @@ public class ImageLike
         init => _discordId = Convert.ToUInt64(value);
     }
     private readonly ulong _discordId;
-    public Guid ImageId { get; init; }
+    public required Guid ImageId { get; init; }
+    public DateTime Date { get; init; } = DateTime.UtcNow;
     
     public ApplicationUser? ApplicationUser { get; init; }
     public UserImage? UserImage { get; init; }


### PR DESCRIPTION
Introduce a new Date property with a default of DateTime.UtcNow. This ensures a timestamp is recorded whenever an ImageLike object is initialized.