### PR TITLE
Switch to GUID for Identity types

### DIFF
--- a/TheCrewCommunity/Data/LiveBotDbContext.cs
+++ b/TheCrewCommunity/Data/LiveBotDbContext.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using TheCrewCommunity.Data.GameData;
 using TheCrewCommunity.Data.TableConfiguration;
 using TheCrewCommunity.Data.WebData;
@@ -6,7 +8,7 @@ using TheCrewCommunity.Data.WebData.ProSettings;
 
 namespace TheCrewCommunity.Data;
 
-public class LiveBotDbContext : DbContext
+public class LiveBotDbContext : IdentityDbContext<ApplicationUser,IdentityRole<Guid>, Guid>
 {
     public DbSet<StreamNotifications> StreamNotifications { get; init; }
     public DbSet<User> Users { get; init; }
@@ -45,6 +47,8 @@ public class LiveBotDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        base.OnModelCreating(modelBuilder);
+        
         modelBuilder.ApplyConfiguration(new ImageLikeConfig());
         modelBuilder.ApplyConfiguration(new UserImageConfig());
         modelBuilder.Entity<ButtonRoles>().HasKey(x => x.Id);

--- a/TheCrewCommunity/Data/WebData/ApplicationUser.cs
+++ b/TheCrewCommunity/Data/WebData/ApplicationUser.cs
@@ -4,7 +4,7 @@ using TheCrewCommunity.Data.WebData.ProSettings;
 
 namespace TheCrewCommunity.Data.WebData;
 
-public class ApplicationUser : IdentityUser
+public class ApplicationUser : IdentityUser<Guid>
 {
     public ulong DiscordId
     {

--- a/TheCrewCommunity/ServiceConfiguration.cs
+++ b/TheCrewCommunity/ServiceConfiguration.cs
@@ -46,7 +46,7 @@ public static class ServiceConfiguration
         services.AddPooledDbContextFactory<LiveBotDbContext>(options => options.UseNpgsql(services.BuildServiceProvider().GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")));
         services.AddDbContext<LiveBotDbContext>(options => options.UseNpgsql(services.BuildServiceProvider().GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")));
         
-        services.AddIdentity<ApplicationUser, IdentityRole>()
+        services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
             .AddEntityFrameworkStores<LiveBotDbContext>();
         
         services.AddAuthentication(options =>


### PR DESCRIPTION
Changed IdentityRole and IdentityUser to use GUIDs instead of default string types. Updated DbContext to extend IdentityDbContext with appropriate GUID configurations.