### PR TITLE
Fixed how top of all time was ordered

### DIFF
--- a/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor.cs
+++ b/TheCrewCommunity/Components/Pages/PhotoMode/Browse.razor.cs
@@ -88,7 +88,7 @@ public partial class Browse : ComponentBase
                 SortImagesByLikes(365);
                 break;
             case SortMode.TopAllTime:
-                _images = _images.OrderByDescending(x => x.ImageLikes).ToArray();
+                _images = _images.OrderByDescending(x => x.LikesCount).ToArray();
                 break;
             default:
                 throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
Fixes how top of all time orders images. Before used a list of likes instead of likes count, thus erroring.