### PR TITLE
Fix tag deletion by parsing tagId to Guid

### DIFF
--- a/TheCrewCommunity/LiveBot/Commands/TagCommands/DeleteTagCommand.cs
+++ b/TheCrewCommunity/LiveBot/Commands/TagCommands/DeleteTagCommand.cs
@@ -16,7 +16,7 @@ public static class DeleteTagCommand
         await ctx.DeferResponseAsync(true);
         ctx.Client.Logger.LogDebug(CustomLogEvents.TagCommand, "User {User} in Guild {Guild} started deleting a tag", ctx.User.Id, ctx.Guild.Id);
         await using LiveBotDbContext liveBotDbContext = await dbContextFactory.CreateDbContextAsync();
-        Tag? tag = await liveBotDbContext.Tags.FindAsync(tagId) ?? null;
+        Tag? tag = await liveBotDbContext.Tags.FindAsync(Guid.Parse(tagId)) ?? null;
         if (tag is null)
         {
             await ctx.EditResponseAsync("Tag not found");


### PR DESCRIPTION
The tag deletion command now correctly parses tagId to a Guid before querying the database. This ensures the tag is properly located and deleted, preventing errors when tagId is not in the expected format.

Fixes https://github.com/BlackLotusLV/TheCrewCommunity/issues/36