### PR TITLE
Handle Discord API errors in StatsCommand

### DIFF
--- a/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/StatsCommand.cs
+++ b/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/StatsCommand.cs
@@ -36,7 +36,16 @@ public static class StatsCommand
         leaderboardBuilder.AppendLine("User".PadRight(30) + "Warnings".PadRight(10) + "Kicks".PadRight(10) + "Bans".PadRight(10));
         foreach (var user in groupedLeaderboard)
         {
-            DiscordUser discordUser = await ctx.Client.GetUserAsync(user.UserId);
+            DiscordUser discordUser;
+            try
+            {
+                discordUser = await ctx.Client.GetUserAsync(user.UserId);
+            }
+            catch (Exception e)
+            {
+                ctx.Client.Logger.LogError(e, "Failed to get user from Discord API. User ID: {ID}", user.UserId);
+                continue;
+            }
             leaderboardBuilder.AppendLine($"{discordUser.Username}#{discordUser.Discriminator}".PadRight(30) + $"{user.Warnings}".PadRight(10) + $"{user.Kicks}".PadRight(10) +
                                           $"{user.Bans}".PadRight(10));
         }


### PR DESCRIPTION
Added a try-catch block to handle potential exceptions when fetching user details from the Discord API. This ensures the stats generation process continues even if some user data retrieval fails, logging the errors for further diagnosis.

fixes https://github.com/BlackLotusLV/TheCrewCommunity/issues/37