### PR TITLE
Add bonus points for booster and supporter users

### DIFF
--- a/TheCrewCommunity/Data/Guild.cs
+++ b/TheCrewCommunity/Data/Guild.cs
@@ -104,6 +104,14 @@ public class Guild
     }
     private readonly ulong? _userReportsChannelId;
 
+    public ulong? SupporterRoleId
+    {
+        get => _supporterRoleId;
+        init => _supporterRoleId = value.HasValue ? Convert.ToUInt64(value) : default(ulong?);
+    }
+
+    private readonly ulong? _supporterRoleId;
+
     public ICollection<GuildUser>? GuildUsers { get; init; }
     public ICollection<RankRoles>? RankRoles { get; init; }
     public ICollection<ButtonRoles>? ButtonRoles { get; init; }


### PR DESCRIPTION
Enhanced the point system to grant additional points for booster users and a multiplier for users with a supporter role. Introduced `BoosterBonus` and `SupporterMultiplier` constants, and updated the `Guild` class to support the `SupporterRoleId` property.