### PR TITLE
Use slash commands for EditNoteCommand and fix autocomplete

### DIFF
--- a/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/EditNoteCommand.cs
+++ b/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/EditNoteCommand.cs
@@ -1,4 +1,4 @@
-﻿using DSharpPlus.Commands;
+﻿using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Entities;
 using DSharpPlus.Interactivity;
 using Microsoft.EntityFrameworkCore;
@@ -8,7 +8,7 @@ using TheCrewCommunity.Services;
 namespace TheCrewCommunity.LiveBot.Commands.ModeratorCommands;
 public static class EditNoteCommand
 {
-    public static async Task ExecuteAsync(IDbContextFactory<LiveBotDbContext> dbContextFactory, IModeratorLoggingService moderatorLoggingService, InteractivityExtension interactivity,CommandContext ctx, DiscordUser user, long noteId)
+    public static async Task ExecuteAsync(IDbContextFactory<LiveBotDbContext> dbContextFactory, IModeratorLoggingService moderatorLoggingService, InteractivityExtension interactivity,SlashCommandContext ctx, DiscordUser user, long noteId)
     {
         if (ctx.Member is null || ctx.Guild is null)
         {
@@ -25,9 +25,11 @@ public static class EditNoteCommand
 
         string oldNote = infraction.Reason??"*No note content*";
         var customId = $"EditNote-{ctx.User.Id}";
-        DiscordInteractionResponseBuilder modal = new DiscordInteractionResponseBuilder().WithTitle("Edit users note").WithCustomId(customId)
+        DiscordInteractionResponseBuilder modal = new DiscordInteractionResponseBuilder()
+            .WithTitle("Edit users note")
+            .WithCustomId(customId)
             .AddComponents(new DiscordTextInputComponent("Content", "Content", null, oldNote, true, DiscordTextInputStyle.Paragraph));
-        await ctx.RespondAsync(modal);
+        await ctx.RespondWithModalAsync(modal);
 
         var response = await interactivity.WaitForModalAsync(customId, ctx.User);
         if (response.TimedOut) return;

--- a/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/UserNotesAutocompleteProvider.cs
+++ b/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/UserNotesAutocompleteProvider.cs
@@ -1,5 +1,6 @@
 ﻿using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
+using DSharpPlus.Entities;
 using Microsoft.EntityFrameworkCore;
 using TheCrewCommunity.Data;
 
@@ -10,13 +11,13 @@ public class UserNotesAutocompleteProvider(IDbContextFactory<LiveBotDbContext> d
     public async ValueTask<IReadOnlyDictionary<string,object>> AutoCompleteAsync(AutoCompleteContext ctx)
     {
         await using LiveBotDbContext dbContext = await dbContextFactory.CreateDbContextAsync();
-        var user = (ulong?)ctx.Options.First(x => x.Name == "user").Value;
+        var user = (ulong?)ctx.Options.First(x => x.Type == DiscordApplicationCommandOptionType.User).Value;
         var infractions = await dbContext.Infractions
             .Where(x => x.InfractionType == InfractionType.Note && x.AdminDiscordId == ctx.User.Id && x.UserId == user).ToListAsync();
         Dictionary<string, object> result = [];
         foreach (Infraction infraction in infractions)
         {
-            result.Add($"#{infraction.Id} - {infraction.Reason}", infraction.Id);
+            result.Add($"#{infraction.Id} - {infraction.Reason}", infraction.Id.ToString());
         }
         return result;
     }


### PR DESCRIPTION
Switched from CommandContext to SlashCommandContext to utilize slash commands. Adjusted interaction response to use modal response for EditNoteCommand. Updated UserNotesAutocompleteProvider to filter by option type and ensure infraction Id is returned as a string.

fixes #45