### PR TITLE
Fix reason formatting in ModeratorWarningService

### DIFF
--- a/TheCrewCommunity/Services/ModeratorWarningService.cs
+++ b/TheCrewCommunity/Services/ModeratorWarningService.cs
@@ -289,7 +289,7 @@ public class ModeratorWarningService(
                     reason.AppendLine($"### {GetReasonTypeEmote(infraction.InfractionType)} Infraction #{infraction.Id} *({infraction.InfractionType.ToString()})*")
                         .AppendLine($"- **By:** <@{infraction.AdminDiscordId}>")
                         .AppendLine($"- **Date:** <t:{infraction.TimeCreated.ToUnixTimeSeconds()}>")
-                        .Append($"- **Reason:** {infraction.Reason}");
+                        .AppendLine($"- **Reason:** {infraction.Reason}");
                     if (infraction.InfractionType == InfractionType.Warning)
                     {
                         reason.AppendLine($"- **Is active:** {(infraction.IsActive ? "✅" : "❌")}");


### PR DESCRIPTION
Corrected the formatting issue for infraction reasons by changing `Append` to `AppendLine`. This ensures that the reason text appears on a new line, improving readability.
Fixed #58 