### PR TITLE
Configure kebab-case naming for slash commands

### DIFF
--- a/TheCrewCommunity/ServiceConfiguration.cs
+++ b/TheCrewCommunity/ServiceConfiguration.cs
@@ -3,7 +3,7 @@ using DSharpPlus;
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.Processors.MessageCommands;
 using DSharpPlus.Commands.Processors.SlashCommands;
-using DSharpPlus.Commands.Processors.TextCommands;
+using DSharpPlus.Commands.Processors.SlashCommands.NamingPolicies;
 using DSharpPlus.Commands.Processors.UserCommands;
 using DSharpPlus.Extensions;
 using DSharpPlus.Interactivity.Extensions;
@@ -129,12 +129,18 @@ public static class ServiceConfiguration
         {
             DebugGuildId = guildId
         };
+
+        SlashCommandConfiguration scConfig = new()
+        {
+            NamingPolicy = new KebabCaseNamingPolicy()
+        };
+        
         services.AddCommandsExtension((_, commands) =>
             {
                 commands.CommandExecuted += SystemEvents.CommandExecuted;
                 commands.CommandErrored += SystemEvents.CommandErrored;
                 commands.AddProcessors(
-                    new SlashCommandProcessor(),
+                    new SlashCommandProcessor(scConfig),
                     new UserCommandProcessor(),
                     new MessageCommandProcessor()
                 );


### PR DESCRIPTION
Added a new `SlashCommandConfiguration` object to enforce kebab-case naming policy for slash commands. This change aims to standardize the naming conventions for better readability and consistency across command names.