### PR TITLE
Upgrade ID generation to use Guid.CreateVersion7()

### DIFF
--- a/TheCrewCommunity/Data/GameData/Brand.cs
+++ b/TheCrewCommunity/Data/GameData/Brand.cs
@@ -4,7 +4,7 @@ namespace TheCrewCommunity.Data.GameData;
 
 public class Brand
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     [MaxLength(30)]
     public required string Name { get; set; }
     [MaxLength(2)]

--- a/TheCrewCommunity/Data/GameData/Game.cs
+++ b/TheCrewCommunity/Data/GameData/Game.cs
@@ -5,7 +5,7 @@ namespace TheCrewCommunity.Data.GameData;
 
 public class Game
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     [MaxLength(30)]
     public required string Name { get; init; }
     public DateOnly ReleaseDate { get; init; }

--- a/TheCrewCommunity/Data/GameData/Vehicle.cs
+++ b/TheCrewCommunity/Data/GameData/Vehicle.cs
@@ -5,7 +5,7 @@ namespace TheCrewCommunity.Data.GameData;
 
 public class Vehicle
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; } = Guid.CreateVersion7();
     public Guid BrandId { get; set; }
     public Guid GameId { get; set; }
     public Guid VCatId { get; set; }

--- a/TheCrewCommunity/Data/GameData/VehicleCategory.cs
+++ b/TheCrewCommunity/Data/GameData/VehicleCategory.cs
@@ -4,7 +4,7 @@ namespace TheCrewCommunity.Data.GameData;
 
 public class VehicleCategory
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; } = Guid.CreateVersion7();
     
     [MaxLength(30)]
     public required string Name { get; set; }

--- a/TheCrewCommunity/Data/Tag.cs
+++ b/TheCrewCommunity/Data/Tag.cs
@@ -7,7 +7,7 @@ public class Tag
     private readonly ulong _ownerId;
     private readonly ulong _guildId;
     
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     
     [MaxLength(30)]
     public required string Name { get; set; }

--- a/TheCrewCommunity/Data/VanityWhitelist.cs
+++ b/TheCrewCommunity/Data/VanityWhitelist.cs
@@ -5,7 +5,7 @@ namespace TheCrewCommunity.Data;
 public class VanityWhitelist
 {
     private readonly ulong _guildId;
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     public required ulong GuildId
     {
         get => _guildId;

--- a/TheCrewCommunity/Data/WebData/ImageLike.cs
+++ b/TheCrewCommunity/Data/WebData/ImageLike.cs
@@ -2,7 +2,7 @@
 
 public class ImageLike
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     public ulong DiscordId
     {
         get => _discordId;

--- a/TheCrewCommunity/Data/WebData/ProSettings/MtfstCarProSettings.cs
+++ b/TheCrewCommunity/Data/WebData/ProSettings/MtfstCarProSettings.cs
@@ -5,7 +5,7 @@ namespace TheCrewCommunity.Data.WebData.ProSettings;
 
 public class MtfstCarProSettings
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
+    public Guid Id { get; init; } = Guid.CreateVersion7();
     public ulong DiscordId
     {
         get => _discordId;

--- a/TheCrewCommunity/Data/WebData/ProSettings/MtfstCarProSettingsLikes.cs
+++ b/TheCrewCommunity/Data/WebData/ProSettings/MtfstCarProSettingsLikes.cs
@@ -2,7 +2,7 @@
 
 public class MtfstCarProSettingsLikes
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; } = Guid.CreateVersion7();
     public ulong DiscordId
     {
         get => _discordId;

--- a/TheCrewCommunity/LiveBot/DiscordEventHandlers/DeleteLog.cs
+++ b/TheCrewCommunity/LiveBot/DiscordEventHandlers/DeleteLog.cs
@@ -104,7 +104,7 @@ public static class DeleteLog
             if (!ImageExtensions.Contains(Path.GetExtension(messageAttachment.FileName??""))) continue;
             HttpResponseMessage response = await httpClient.GetAsync(messageAttachment.Url);
             if (!response.IsSuccessStatusCode) continue;
-            var uniqueFileName = $"{Guid.NewGuid()}-{messageAttachment.FileName}";
+            var uniqueFileName = $"{Guid.CreateVersion7()}-{messageAttachment.FileName}";
             MemoryStream ms = new();
             await response.Content.CopyToAsync(ms);
             ms.Position = 0;


### PR DESCRIPTION
Replaced instances of Guid.NewGuid() with Guid.CreateVersion7() across multiple data classes to standardize ID creation and ensure better UUID generation. This change affects entities such as MtfstCarProSettings, Vehicle, and Tag, among others.