### PR TITLE
Fix broken URL in Ubisoft Code of Conduct link

### DIFF
--- a/TheCrewCommunity/Components/Pages/Rules.razor
+++ b/TheCrewCommunity/Components/Pages/Rules.razor
@@ -14,7 +14,7 @@ Not knowing the rules does not free you from responsibility.
 <h4>Discord Rules</h4>
 <ul>
     <li>You must comply with <a href="https://discord.com/guidelines">Discords Guidelines</a>.</li>
-    <li>You must comply with Ubisoft <a href="https//www.ubisoft.com/help?article=000095037">Code of Conduct</a>.</li>
+    <li>You must comply with Ubisoft <a href="https://www.ubisoft.com/help?article=000095037">Code of Conduct</a>.</li>
     <li>Any kind of advertisement is not allowed. No plugging of your content outside of the specified channels.</li>
     <li>Do not be disruptive to the community. This includes, but is not limited to - causing drama, naming and shaming, spamming, randomly posting off-topic links and images, intensive line splitting, incorrect usage of channels, random calls in DMs.</li>
     <li>Do not post content that contains pornographic imagery or anything that would be considered not safe for work.</li>


### PR DESCRIPTION
Corrected the URL for the Ubisoft Code of Conduct to include the missing protocol (https://) which ensures the link is functional and directs users to the intended webpage.