### PR TITLE
Refactor Levenshtein distance calculation

### DIFF
--- a/TheCrewCommunity/GeneralUtils.cs
+++ b/TheCrewCommunity/GeneralUtils.cs
@@ -11,24 +11,33 @@ public class GeneralUtils
                member.Permissions.HasPermission(DiscordPermissions.BanMembers) ||
                member.Permissions.HasPermission(DiscordPermissions.Administrator);
     }
-    
-    public int CalculateLevenshteinDistance(string a, string b)
+
+    public int CalculateLevenshteinDistance(ReadOnlySpan<char> str1, ReadOnlySpan<char> str2)
     {
-        var matrix = new int[a.Length + 1, b.Length + 1];
-
-        for (var i = 0; i <= a.Length; i++)
-            matrix[i, 0] = i;
-        for (var j = 0; j <= b.Length; j++)
-            matrix[0, j] = j;
-
-        for (var i = 1; i <= a.Length; i++)
+        if (str1 == null) throw new ArgumentNullException(nameof(str1));
+        if (str2 == null) throw new ArgumentNullException(nameof(str2));
+        if (str1.Length == 0) return str2.Length;
+        if (str2.Length == 0) return str1.Length;
+        
+        Span<int> prevRow = stackalloc int[str2.Length + 1];
+        Span<int> currRow = stackalloc int[str2.Length + 1];
+        
+        for (var j = 0; j <= str2.Length; j++)
+            prevRow[j] = j;
+        for (var i = 1; i <= str1.Length; i++)
         {
-            for (var j = 1; j <= b.Length; j++)
+            currRow[0] = i;
+
+            for (var j = 1; j <= str2.Length; j++)
             {
-                int cost = b[j - 1] == a[i - 1] ? 0 : 1;
-                matrix[i, j] = Math.Min(Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1), matrix[i - 1, j - 1] + cost);
+                int cost = (str1[i - 1] == str2[j - 1]) ? 0 : 1;
+                currRow[j] = Math.Min(Math.Min(prevRow[j] + 1, currRow[j - 1] + 1), prevRow[j - 1] + cost);
             }
+
+            var temp = prevRow;
+            prevRow = currRow;
+            currRow = temp;
         }
-        return matrix[a.Length, b.Length];
+        return prevRow[str2.Length];
     }
 }


### PR DESCRIPTION
Switch to using ReadOnlySpan<char> for strings in CalculateLevenshteinDistance to improve performance and memory usage. Add null checks and optimize the algorithm by using stack-allocated arrays for intermediate computations.