### PR TITLE
Add PageTitle component and cache-busting for styles

### DIFF
--- a/TheCrewCommunity/Components/App.razor
+++ b/TheCrewCommunity/Components/App.razor
@@ -7,7 +7,7 @@
     <base href="/"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="app.css"/>
-    <link rel="stylesheet" href="TheCrewCommunity.styles.css"/>
+    <link rel="stylesheet" href="TheCrewCommunity.styles.css?v=@Guid.CreateVersion7()"/>
     <link rel="icon" type="image/png" href="favicon.ico"/>
     <HeadOutlet/>
 </head>

--- a/TheCrewCommunity/Components/Pages/Map.razor
+++ b/TheCrewCommunity/Components/Pages/Map.razor
@@ -1,4 +1,6 @@
 ﻿@page "/Map"
+
+<PageTitle>Tomco's Map</PageTitle>
 <h3>Tomco's map</h3>
 <iframe src="https://tcminteractivemap.netlify.app/" frameborder="0" allowfullscreen></iframe>
 @code {


### PR DESCRIPTION
Added a PageTitle component to the Map.razor file to enhance SEO and user accessibility. Implemented a cache-busting mechanism for the stylesheet in App.razor to ensure users receive the latest version without manual cache clearing.