### PR TITLE
Increase session timeout duration to 1 day

### DIFF
--- a/TheCrewCommunity/ServiceConfiguration.cs
+++ b/TheCrewCommunity/ServiceConfiguration.cs
@@ -111,7 +111,7 @@ public static class ServiceConfiguration
         
         services.AddSession(options =>
         {
-            options.IdleTimeout = TimeSpan.FromSeconds(30);
+            options.IdleTimeout = TimeSpan.FromDays(1);
             options.Cookie.HttpOnly = true;
             options.Cookie.IsEssential = true;
         });


### PR DESCRIPTION
### Description
Update the session timeout duration from 30 seconds to 1 day to improve user experience with longer sessions.