### PR TITLE
Update dependency versions and configure command naming policy

### DIFF
--- a/TheCrewCommunity/ServiceConfiguration.cs
+++ b/TheCrewCommunity/ServiceConfiguration.cs
@@ -3,6 +3,7 @@ using DSharpPlus;
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.Processors.MessageCommands;
 using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
 using DSharpPlus.Commands.Processors.UserCommands;
 using DSharpPlus.Extensions;
 using DSharpPlus.Interactivity.Extensions;
@@ -151,7 +152,12 @@ public static class ServiceConfiguration
         }
         CommandsConfiguration commandsConfiguration = new()
         {
-            DebugGuildId = guildId
+            DebugGuildId = guildId,
+            RegisterDefaultCommandProcessors = false,
+        };
+        SlashCommandConfiguration slashCommandConfiguration = new()
+        {
+            NamingPolicy = new KebabCaseNamingPolicy()
         };
         
         services.AddCommandsExtension((_, commands) =>
@@ -159,7 +165,7 @@ public static class ServiceConfiguration
                 commands.CommandExecuted += SystemEvents.CommandExecuted;
                 commands.CommandErrored += SystemEvents.CommandErrored;
                 commands.AddProcessors(
-                    new SlashCommandProcessor(),
+                    new SlashCommandProcessor(slashCommandConfiguration),
                     new UserCommandProcessor(),
                     new MessageCommandProcessor()
                 );

--- a/TheCrewCommunity/TheCrewCommunity.csproj
+++ b/TheCrewCommunity/TheCrewCommunity.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
       <PackageReference Include="AspNet.Security.OAuth.Discord" Version="9.0.0" />
-      <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02443" />
-      <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02443" />
-      <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02443" />
+      <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02461" />
+      <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02461" />
+      <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02461" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">

--- a/TheCrewCommunity/TheCrewCommunity.csproj
+++ b/TheCrewCommunity/TheCrewCommunity.csproj
@@ -12,13 +12,13 @@
       <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02461" />
       <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02461" />
       <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02461" />
-      <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
       <PackageReference Include="Serilog" Version="4.2.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />


### PR DESCRIPTION
### Summary

This pull request includes the following updates:
- **Dependency Updates**:  
  Upgraded Microsoft.EntityFrameworkCore and related packages to version 9.0.2, and Npgsql.EntityFrameworkCore.PostgreSQL to version 9.0.4. These updates ensure compatibility with the latest improvements and bug fixes without introducing functionality changes.
  
- **DSharpPlus Configuration**:  
  Upgraded DSharpPlus packages to the nightly version 02461. Configured slash command naming policy using `KebabCaseNamingPolicy` for consistent command naming. Also, disabled default command processors.
