### PR TITLE
Add 12-hour timeout option to WarnCommand

### DIFF
--- a/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/WarnCommand.cs
+++ b/TheCrewCommunity/LiveBot/Commands/ModeratorCommands/WarnCommand.cs
@@ -36,6 +36,7 @@ public static class WarnCommand
         [Description("5 min")] FiveMin = 300,
         [Description("10 min")] TenMin = 600,
         [Description("1 hour")] OneHour = 3600,
+        [Description("12 hour")] TwelveHour = 43200,
         [Description("1 day")] OneDay = 86400,
         [Description("1 week")] OneWeek = 604800
     }


### PR DESCRIPTION
### Description

This pull request introduces a 12-hour timeout option for the `WarnCommand`. The update expands the existing timeout settings, offering more flexibility for issuing warnings with a specific duration