### PR TITLE
Prevent duplicate votes in "This or That"

### DIFF
--- a/TheCrewCommunity/Components/Pages/ThisOrThat/TOTVote.razor
+++ b/TheCrewCommunity/Components/Pages/ThisOrThat/TOTVote.razor
@@ -313,6 +313,14 @@ else
             VotedForVehicleId = selected.Id,
         };
         await using LiveBotDbContext dbContext = await DbContextFactory.CreateDbContextAsync();
+        if (dbContext.SuggestionVotes.Any(x=>x.UserId==CurrentUser.Id && ((x.VehicleSuggestion1Id==CurrentChoice.Value.Item1.Id && x.VehicleSuggestion2Id==CurrentChoice.Value.Item2.Id)||(x.VehicleSuggestion1Id==CurrentChoice.Value.Item2.Id && x.VehicleSuggestion2Id==CurrentChoice.Value.Item1.Id))))
+        {
+            _addingVote = false;
+            GenerateUniquePairList();
+            CurrentChoice = await GenerateRandomSuggestionVoteAsync();
+            ResetSwipeState();
+            return;
+        }
         dbContext.SuggestionVotes.Add(vote);
         await dbContext.SaveChangesAsync();
         var matchupVotes = await dbContext.SuggestionVotes.Where(x => x.VehicleSuggestion1Id == CurrentChoice.Value.Item1.Id && x.VehicleSuggestion2Id == CurrentChoice.Value.Item2.Id || x.VehicleSuggestion1Id == CurrentChoice.Value.Item2.Id && x.VehicleSuggestion2Id == CurrentChoice.Value.Item1.Id).ToListAsync();


### PR DESCRIPTION
This pull request introduces validation logic to prevent duplicate votes on existing suggestions in the "This or That" feature.

Issue occurs when multiple instances of the page are opened. Be it in different tabs or multiple devices, the list was only updated on first load. Now it updates if it detects a duplicate entry.